### PR TITLE
Properly address PTC-63. :bow:

### DIFF
--- a/modules/lib/search.xql
+++ b/modules/lib/search.xql
@@ -112,7 +112,7 @@ declare
 function search:show-hits($node as node()*, $model as map(*), $start as xs:integer, $per-page as xs:integer, $view as xs:string?) {
     if ($model?error)
         then
-            let $loc := <span id="error-message"><strong>Invalid Search</strong><p>There is something wrong with the phrase you searched for. If using quotes for multi-word, exact phrase searching, please check that you have properly closed the quotes around the phrase, ex: "San Francisco", and then try again.</p></span>
+            let $loc := <div id="error-message" role="alert"><strong>Invalid Search</strong><p>There is something wrong with the phrase you searched for. If using quotes for multi-word, exact phrase searching, please check that you have properly closed the quotes around the phrase, ex: "San Francisco", and then try again.</p></div>
             return ($loc)
     else
     for $hit at $p in subsequence($model("hits"), $start, $per-page)


### PR DESCRIPTION
**JIRA Ticket**: [PTC-63](https://jira.lib.utk.edu/browse/PTC-63)

# What does this Pull Request do?

This gets rid of search errors when someone submits a query without a closing or starting double quote.

# What's new?

I added another conditional to our search query function. In it, I test to see if we have an odd number of double quotes in our query string.  If we do, I do a couple of things:

1. I change the query to "Invalid query!  Try again." This makes sure the user sees a prompt that they've made an illegal search.  
2. I set the hitCount  to 0.
3. I pass an empty map to session:set-attribute for hits.  This way, when it iterates over the iterable that represents our hits, nothing is there.  By doing this, we make sure there are no errors, but we also ensure nothing is returned to the DOM and clear any results from previous successful searches.
4. I pass an empty string as our doc.

# How should this be tested?

1. ant
2. import app
3. do a search for Caldwell
4. do a search for "Caldwell
5. do a search for Caldwell"
6. do a search for "Caldwell"
7. do a search for "Caldwell""

# Additional Notes

I'll admit, i introduce a potential issue here, but I feel strongly that it is a bit far-fetched.  The issue is this:  I someone performs a search with a properly escaped double quote, we'll pass them this same message.  I don't think that is likely, but if you want to argue about it, let's go. :boxing_glove: :martial_arts_uniform: :boxing_glove: 

# Interested parties
@CanOfBees @mathewjordan 
