### PR TITLE
Address PTC-73: normalize ellipses so that they adhere to the Chicago Manual of Style.

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -3417,10 +3417,10 @@
               J. Donelson</name>, <date when="1848-02-02">April 2, 1848</date>) to Congress, Polk
             approves Rush’s recognition of the new French government, expresses the United States’
             “congratulations” toward the French people, affirms <name type="place">America</name>’s
-            “policy ... of non-intervention in the domestic affairs of other countries” but its
+            “policy . . . of non-intervention in the domestic affairs of other countries” but its
             support for “free government” everywhere, and asserts, “The world has seldom witnessed a
             more interesting or sublime spectacle than the peaceful rising of the French people,
-            resolved to secure for themselves enlarged liberty, and to assert ... the great truth,
+            resolved to secure for themselves enlarged liberty, and to assert . . . the great truth,
             that in this enlightened age man is capable of governing himself.” Senate Executive
             Document No. 32, 30th Congress, 1st Session, pp. 1–2.</note>
                 </p>
@@ -3800,7 +3800,7 @@
             for itself about slavery. Toucey adds that Northerners have no “right to interfere with”
             slavery in the South and that abolitionist control of Northern state governments would
             spell the end of the United States: “<name type="org">America</name> would be drenched
-            in the blood of our countrymen slain by each other’s hands, and the last hope of <name type="org">African</name> emancipation ... would be extinguished forever.”
+            in the blood of our countrymen slain by each other’s hands, and the last hope of <name type="org">African</name> emancipation . . . would be extinguished forever.”
               <abbr>DLC–JKP</abbr>.</note>
                 </p>
         <p>He has ever since maintained the same ground and has of late done much to establish a
@@ -3991,7 +3991,7 @@
           highest degree gratifying to us all, &amp; produced the happiest effect in our new sister
           republic, the prospects of which are now very encouraging, as the elections have just gone
           off, very quietly &amp; will probably result in the choice of an overwhelming majority,
-          pledged equally to order &amp; to liberty. ...</p>
+          pledged equally to order &amp; to liberty. . . .</p>
         <closer>
           <signed>J L M<hi rend="sc">ARTIN</hi>
                     </signed>
@@ -5132,7 +5132,7 @@
             against the <name type="place">United States</name>. Noting the <abbr>U.S.</abbr>
             “policy to repel rather than encourage Indian depredations and incursions even on our
             enemy,” <name type="person">Mason</name> instructs <name type="person">Perry</name>,
-            “waiving all belligerent rights against Yucatán as a part of <name type="place">Mexico</name>, ... [to] permit munitions of war to enter her ports, if you are
+            “waiving all belligerent rights against Yucatán as a part of <name type="place">Mexico</name>, . . . [to] permit munitions of war to enter her ports, if you are
             satisfied they are to be used for the defence of the whites against the savage enemy.”
               <name type="person">Mason</name> advises “strengthen[ing] your forces at El Carmen”
             and sending the marines at Alvarado to Laguna de Términos “to repel the Indians if they
@@ -5670,7 +5670,7 @@
           occupied &amp; have relieved the convention of any possible embarrassment, wh[ich]<note place="foot" n="6">Letters cut off side of page.</note> the suggestion of my name for
           re-nomination might produce. Who will be the nominee is regarded as uncertain by all who
           have conversed with me on the subject. With Respectful regards to <name type="person">Mrs.
-            C.</name> ...</p>
+            C.</name> . . .</p>
         <closer>
           <signed>J<hi rend="sc">AMES</hi> K. P<hi rend="sc">OLK</hi>
                     </signed>
@@ -6151,7 +6151,7 @@
           authenticated copy of a Joint Resolution of that body, approved on the 9th ultimo,
           entitled “Joint Resolution of thanks to Major General <name type="person">Taylor</name>.”<note place="foot" n="1">The enclosure has not been found, though the
             manuscript envelope for it has. <abbr>DLC–ZT</abbr>. The joint resolution thanked <name type="person">Taylor</name> and the other officers and soldiers “for their valor,
-            skill, and good conduct ... in the battle of Buena Vista”; it directed <name type="person">Polk</name> to inform <name type="person">Taylor</name> of the
+            skill, and good conduct . . . in the battle of Buena Vista”; it directed <name type="person">Polk</name> to inform <name type="person">Taylor</name> of the
             resolution and to present him with a gold medal. <hi rend="italics">SL</hi>, 30th
             Congress, 1st Session, Number 7.</note> As soon as the gold medal directed by the
           Resolution to be struck can be prepared it will be presented to you.</p>
@@ -6254,7 +6254,7 @@
           think will come out “right side up.” I have written more lengthily than I intended. I
           would transcribe the letter but have not time, you will therefore please excuse mistakes.
           Be obigling enough to present my best respects to <name type="person">Mrs. Polk</name> and
-          accept for yourself my best wishes too for your prosperity and happiness. ...</p>
+          accept for yourself my best wishes too for your prosperity and happiness. . . .</p>
         <closer>
           <signed>J<hi rend="sc">OHN</hi> L B<hi rend="sc">ROWN</hi>
                     </signed>
@@ -6800,7 +6800,7 @@
             “sister Republic” ten “great principles illustrated in our history”: (1) that Americans’
             commitment to the Bible enabled the writing, adoption, and preservation of the
             Constitution; (2) that <abbr>U.S.</abbr> officials “recognise[d] the government of God”;
-            (3) that they honored the Sabbath; (4) that “they ordered ... the importation of many
+            (3) that they honored the Sabbath; (4) that “they ordered . . . the importation of many
             thousand copies of the Bible”; (5) that, at <name type="person">Benjamin
             Franklin</name>’s suggestion, the authors of the Constitution sought God’s “guidance”;
             (6) that the government has begun each day by seeking God’s guidance; (7) that Americans
@@ -6987,7 +6987,7 @@
             examiner, thus “Violating the spirit and tradition of the Law of 1839,” which created
             the training position of assistant examiner; (17) “General neglect of the business of
             the Office and appropriation of the business hours to political &amp; personal writing
-            ... and employing his subordinates during Office hours on his own personal or private
+            . . . and employing his subordinates during Office hours on his own personal or private
             affairs”; (18) “General absence from the Office during Office hours, [and] coming late
             and going early”; (20) “Exercising generally a tyrannical deportment and insolent
             bearing towards his subordinates in Office; subjecting them to his oaths, illtemper and
@@ -8397,7 +8397,7 @@
           says <name type="person">Genl. Taylor</name> has not the least chance in that section of
             <name type="place">Ohio</name>. In our flourishing Town, he remarked to some Gent., you
           are mostly whigs here. Yes was the reply and he added all go for <name type="person">Taylor</name>, I suppose. The reply was Taylor cannot get 3 votes in Town out of
-          several hundred. ...</p>
+          several hundred. . . .</p>
         <closer>
           <signed>J. G<hi rend="sc">OULD</hi>
                     </signed>
@@ -8804,7 +8804,7 @@
               York City</name> by the <hi rend="italics">Cambria</hi>, from British “Tory papers, is
             intended to deceive the public, and to depress the cause of <name type="place">Ireland</name>. Collisions have
             occurred, the precise result of which cannot be stated, as the patriotic journals are
-            all suppressed. But known events ... are all eocouraging. The whole Government force has
+            all suppressed. But known events . . . are all eocouraging. The whole Government force has
             been employed for a week in attempts to arrest the leaders without effecting a single
             capture. Those leaders have adopted the most effectual means, and will be successful.”
             The authors call for “prompt and continued action” by “our friends in every part of the
@@ -9369,12 +9369,12 @@
             House-initiated resolution to give the president the option—in lieu of offering Texas
             annexation outright—to appoint a commission to reopen treaty negotiations, a process
             that Sen. <name type="person">Thomas H. Benton</name> had proposed and that <name type="person">Tappan</name> believes would have averted the Mexican War; and (3) that
-            Sen. <name type="person">William H. Haywood, <pb/>Jr.</name>, “told me that he <hi rend="italics">was authorized by <name type="person">Mr. Polk</name> to say ... that
-              ... he ... would submit the Senate amendment as the sole proposition to Texas</hi>.”
+            Sen. <name type="person">William H. Haywood, <pb/>Jr.</name>, “told me that he <hi rend="italics">was authorized by <name type="person">Mr. Polk</name> to say . . . that
+              . . . he . . . would submit the Senate amendment as the sole proposition to Texas</hi>.”
             The Tyler administration did, however, offer annexation outright and <name type="person">Polk</name> reaffirmed that decision. <name type="person">Blair</name> asserts that
             President-Elect <name type="person">Polk</name> gave him, then editor of the <name type="place">Washington</name>
             <hi rend="italics">Globe</hi>, “<hi rend="italics">full assurance that he would appoint
-              a commission ... if passed in conjunction with the House resolution as an
+              a commission . . . if passed in conjunction with the House resolution as an
               alternative</hi>” and gave the same “<hi rend="italics">assurance</hi>” to Haywood and
             Sen. <name type="person">John A. Dix</name>. After <name type="person">Polk</name>’s
             inauguration, according to <name type="person">Blair</name>, the president told <name type="person">Dix</name> that “<hi rend="italics">he intended the instant recall of
@@ -10205,7 +10205,7 @@
           considerable excitement and division of opinion is that <pb/>to which you allude in your
           letter and,<note place="foot" n="3">
                         <name type="person">Polk</name> probably meant to
-            place “is ... and,” which he inserted with a caret, after the comma.</note> relates to
+            place “is . . . and,” which he inserted with a caret, after the comma.</note> relates to
           the organization of Governments, in the territories recently acquired from <name type="place">Mexico</name>, and this would be readily settled (and I hope will be during
           my time) were it not for the agitation, of the delicate and distracting question of
           slavery. Much excitement existed in Congress, upon this subject, during the last weeks of
@@ -10404,7 +10404,7 @@
           ablest men of both parties are in the field, addressing the people in mass meetings. <hi rend="italics">
                         <name type="person">Gov. A. V. Brown</name>
                     </hi> is performing, Herculian
-          labour. At my last accounts he was addressing the people from day to day, in <name type="place">East Tennessee</name>. The contest in t[...] State will be bitter and
+          labour. At my last accounts he was addressing the people from day to day, in <name type="place">East Tennessee</name>. The contest in t[. . .] State will be bitter and
           close. From all the information I have I think, the Democracy will ca[rr]y the State,
           though this result cannot be regarded as certain.</p>
         <p>I shall at all times be pleased to hear fro[m] you.</p>
@@ -10450,8 +10450,8 @@
           valuation o[n] his part, and have informed him that you would select another on my
             part.<note place="foot" n="3">
                         <name type="person">Polk</name> to <name type="person">Vernon K. Stevenson</name>, <date when="1848-09-02">September 2, 1848</date>.</note>
-          I wish t[...] business attended to before you leave home on your return to Washington. The
-          house is to [...] delivered to <hi rend="italics">
+          I wish t[. . .] business attended to before you leave home on your return to Washington. The
+          house is to [. . .] delivered to <hi rend="italics">
                         <name type="person">Mr
             Hughes</name>
                     </hi> at the valuation which may be placed on it, on the 1st of January
@@ -10464,7 +10464,7 @@
                     <pb/>All appears to be quiet in <name type="place">Washington</name>, there being but few
           strangers in the City, but, notwithstanding this, I do not see that my labours are much
           diminished.</p>
-        <p>The prospects are decidedly favourable [...] <hi rend="italics">
+        <p>The prospects are decidedly favourable [. . .] <hi rend="italics">
                         <name type="person">Cass</name>’s</hi> election. Indeed judging from present appearances I should
           consider that result cert[ain]. The result of no election however is certain until it has
           taken place, and therefore the Democratic party, should not relent in its exertions. I see
@@ -10668,10 +10668,10 @@
           intermarriages, except those of my own immediate branch of his family, nor of his Great
           Grand children and <pb/>their intermarriag[es]<note place="foot" n="4">Letters cut off
             side of page.</note> and issue. These are very numerous. I possess I believe as accurate
-          knowledge [...] them as any one man living, and if you desire it, will furnish you with
-          their [...]s intermarriages and issue. I shall be under [ad]ditional obligations to you,
-          if you will [fur]nish me with the “tree and short history [...] biography,” which you
-          inform me you [...] preparing.</p>
+          knowledge [. . .] them as any one man living, and if you desire it, will furnish you with
+          their [. . .]s intermarriages and issue. I shall be under [ad]ditional obligations to you,
+          if you will [fur]nish me with the “tree and short history [. . .] biography,” which you
+          inform me you [. . .] preparing.</p>
         <p>In one of your communications you inform me that a correspondence took place in the
           spring of <date when="1824">1824</date>, between <hi rend="italics">
                         <name type="person">Col. William Polk</name>
@@ -10688,7 +10688,7 @@
                         <name type="person">Ezekiel</name>
                     </hi> was a member of the Mecklenburg
           convention, which in <date when="1775-05">May 1775</date>, first proclaimed Independence,
-          and he commanded [...] company of Whig Rangers,” I know also, from the same source, to be
+          and he commanded [. . .] company of Whig Rangers,” I know also, from the same source, to be
           correct. His original commission as a Captain has been preserved, and I have it now in my
           possessi[on]. I would be pleased to receive from you any additional information, which may
           be in your possession and upon which your [substance] is based.</p>
@@ -10872,7 +10872,7 @@
           will continue to write to me, once every month. I wish you to forward my cotton to <hi rend="italics">
                         <name type="org">Pickett Perkins &amp; Co</name>
                     </hi> of <name type="place">New Orleans</name> as you did last year. As you make the bales, send me
-          their weights and numbers. I have not yet sold my last year’s crop, [...]<note place="foot" n="1">Word illegible, light and blurred ink transfer.</note> I suppose the
+          their weights and numbers. I have not yet sold my last year’s crop, [. . .]<note place="foot" n="1">Word illegible, light and blurred ink transfer.</note> I suppose the
           hands are becoming impatient to receive the price of the <hi rend="italics">four bags</hi>
           which belong to them, and which were shipped with my cotton. If they will be better
           satisfied, you can at the end of the present picking season, sell the part wh[ich]<note place="foot" n="2">Text here and below either absent or cut off side of page.</note> you
@@ -12198,7 +12198,7 @@
           quieted I think it must soon rise. Under all the circumstances however I conclude to say
           to you, and you can so instruct your House in <name type="place">New Orleans</name>, that
           they are authorized at their discretion to sell, both crops, last year’s and this, or such
-          of the latter as they may have [... account]<note place="foot" n="2">Words here illegible
+          of the latter as they may have [. . . account]<note place="foot" n="2">Words here illegible
             or uncertain and letter below missing, light ink transfer.</note> at an average price
           not less than 6. cents per pound. If I cannot get an average price of 6. cents per pound,
           I will retain both crops for another year. I do not think it probable that the disturbed
@@ -12316,7 +12316,7 @@
                     </hi> be elected I have great
           confidence this will be done. The country is prosperous in spite of the embarrassments to
           her foreign commerce which must be temporary, <note place="foot" n="1">
-                        <name type="person">Polk</name> may have meant to place “which ... temporary,” which he inserted with a
+                        <name type="person">Polk</name> may have meant to place “which . . . temporary,” which he inserted with a
             caret, between the commas.</note> produced by the political disturbances abroad. During
           my term, <name type="place">Texas</name> has been annexed, the Oregon question has been
           settled, the <name type="place">Mexican</name> war closed by an honourable peace, adding
@@ -12766,7 +12766,7 @@
           of the Whigs will to a great extent desert their candidate, and go for <hi rend="italics">Taylor</hi>, while the Democrats of the same creed will more generally hold to their
           ticket. Can nothing be done, during the few days which yet remain to prevent this? Surely
           the <hi rend="italics">Free Soil</hi> Democrats must see, that the only effect of
-            th[...]<note place="foot" n="2">Letter or letters here and below cut off side of
+            th[. . .]<note place="foot" n="2">Letter or letters here and below cut off side of
             page.</note> course must be to endanger the election of the Democratic candidate. I
           cannot believe, if the subject is presented to them in the proper light, that they can be
           willing, to overthrow their party and its principles, by with-holding their votes, and
@@ -15342,7 +15342,7 @@
           my debts that this 6000$ would pay so that I could save myself. I expect to be in the City
           during the session. If a few Selfish men of our party had not forced me from runing for
           Governor of this State, I could have been elected &amp; that would have elected Cass.
-          ...</p>
+          . . .</p>
         <closer>
           <signed>Rh M J<hi rend="sc">OHNSON</hi>
                     </signed>
@@ -15389,7 +15389,7 @@
           examination. I hope in your case, it may be otherwise. You should devote every moment of
           your time to your studies to the end that you may pass as reputab[le] an examination as
           possible. I hope f[or] the best, but a few weeks will determine what your standing in your
-          class is. I write you thus plainly for your good [...] hope you may profit by it. Your
+          class is. I write you thus plainly for your good [. . .] hope you may profit by it. Your
           future standing and reputation will depend upon your own conduct, at the Academy.</p>
         <p>I write this letter with pain. It would give me sincere pleasure, if I could write one of
           a different character commending you for your good conduct. With the Reports for <hi rend="italics">October</hi> and <hi rend="italics">November</hi> before me, this I
@@ -15988,7 +15988,7 @@
           Triumphant as your inauguration and it is thought by many that your Country will again
           Call you to the helm in: 52. I will nevertheless pray for the Best Notwithstanding I
           should be Truly gratified to see you re Elected in, <date when="1852">1852</date>
-                    <note place="foot" n="2">New sentence may begin before or after “Notwithstanding ... <date when="1852">1852</date>.”</note> yet in the intervening Time I Truly hope that the
+                    <note place="foot" n="2">New sentence may begin before or after “Notwithstanding . . . <date when="1852">1852</date>.”</note> yet in the intervening Time I Truly hope that the
           Councils of the Nation may be Such as to favourably promote the advancement and interest
           of those that are governed and that you in common may rejoice <pb/>to see the policy of
           your wise Administration looked to for a precedent for the Succeeding 4 years. I cannot
@@ -16001,7 +16001,7 @@
           Introducing his Son to that Institution? If not I know that your Other important business
           in which the Whole people are concerned occupies your Time and therefore your Devotion is
           more wisely appropriated and all is Submitted by me to your own better Judgement and more
-          provident care. ...</p>
+          provident care. . . .</p>
         <closer>
           <signed>T<hi rend="sc">IMOTHY</hi> C<hi rend="sc">ORBIN</hi>
                     </signed>
@@ -16083,7 +16083,7 @@
         <p>Permit me to congratulate you on the brilliant success of your administration. As a
           native Tennessean, I feel proud of the honour and glory that have accrued to my native
           state and to the whole country from the talents, energy and patriotic devotion of the
-          Tennessee Presidents. ...</p>
+          Tennessee Presidents. . . .</p>
         <closer>
           <signed>W<hi rend="sc">M</hi>. W. L<hi rend="sc">EA</hi>
                     </signed>
@@ -16275,7 +16275,7 @@
           fraud I do not doubt. Indeed I have never known a [public]-man who professed to belong to
             <hi rend="italics">no party</hi>, who was not when he obtained power a proscriptive, if
           not a vindictive partisan. Your case would test the <hi rend="italics">no party</hi>
-          professions of the President elect, and of his leading frieds. If [...]<note place="foot" n="4">Word or letters here and below cut off side of page.</note> shall prescribe “<hi rend="italics">for opinion’s sake</hi>,” the early [an]d constant friend of <hi rend="italics">Jackson</hi>, one who fell wounded in battle by his side, and who of all the officers,
+          professions of the President elect, and of his leading frieds. If [. . .]<note place="foot" n="4">Word or letters here and below cut off side of page.</note> shall prescribe “<hi rend="italics">for opinion’s sake</hi>,” the early [an]d constant friend of <hi rend="italics">Jackson</hi>, one who fell wounded in battle by his side, and who of all the officers,
           of all grades who had been under his command, was deemed by him most worthy to intrust his
             <hi rend="italics">war sword</hi>, the public will be at no loss to understand and to
           appreciate the insincerity of the professions of moderation, which were made before the
@@ -16615,7 +16615,7 @@
           as was filled by <hi rend="italics">
                         <name type="person">Judge Campbell</name>
                     </hi> of
-            <name type="place">Nashville</name>, <hi rend="italics">Saunders</hi> of [...]<note place="foot" n="1">Word or words cut off side of page.</note>
+            <name type="place">Nashville</name>, <hi rend="italics">Saunders</hi> of [. . .]<note place="foot" n="1">Word or words cut off side of page.</note>
           <hi rend="italics">Kane</hi> of <name type="place">Philadelphia</name>, under the French
           Treaty. Being in the Nature of a Judicial office, I think it probable that the rule of
           proscription for “<hi rend="italics">opinion’s sake</hi>,” which may be adopted by my
@@ -16789,7 +16789,7 @@
           and is now before Congress and no serious opposition to it, if any, is anticipated. I have
           been called upon by two Senators, since the news of <hi rend="italics">
                         <name type="person">Sevier</name>’</hi>s death wa[s] received, to urge me to make another nomination
-          without delay, so as to give time for [...] person appointed to reach <hi rend="italics">San-Diego</hi> within [...] time limited in the Treaty. In view of all the
+          without delay, so as to give time for [. . .] person appointed to reach <hi rend="italics">San-Diego</hi> within [. . .] time limited in the Treaty. In view of all the
           circumstances, I shall probably make a nomination to the Senate on tomorrow, for
           commissioner to run the boundary.</p>
         <p>In coming this conclusion, I have consulted <hi rend="italics">
@@ -17090,7 +17090,7 @@
           wou[ld] have to notice in an authorized form, any article which appeared in its columns,
           in which the facts assumed or the arguments used did not prcisely correspond with hi[s]
           own views. This would make the Presi[dent] virtually the Editor of the paper, a vocati[on]
-          incompatible with his official station, [...] which he would have no time to pursue. Where
+          incompatible with his official station, [. . .] which he would have no time to pursue. Where
           “reason is left free to combat error,” as is the case in our country, no permanent injury
           can result to any citizen, whether in public or private life, from any abuse of the
           freedom of the press.</p>
@@ -18739,7 +18739,7 @@
           eighteen miles. You and your family must stop at my house; where I need scarcely assure
           you; you will meet with friends. If you can remain several days with us, we will be
           pleased. I will probably meet you at Macon; and will certainly do so, if some professional
-          business does not prevent. ...</p>
+          business does not prevent. . . .</p>
         <closer>
           <signed>W<hi rend="sc">ALTER</hi>. T. C<hi rend="sc">OLQUITT</hi>
                     </signed>
@@ -21535,7 +21535,7 @@
         <p>There have been a few cases of cholera here within the last week, which have produced
           some excitement among the inhabitants. It is not considerd epidemic &amp; I have heard of
           no case, for a day or two past.</p>
-        <p>With the kind respects of <name type="person">Mrs. P.</name> &amp; myself to <name type="person">Mrs. J.</name>...</p>
+        <p>With the kind respects of <name type="person">Mrs. P.</name> &amp; myself to <name type="person">Mrs. J.</name>. . .</p>
         <closer>
           <signed>J<hi rend="sc">AMES</hi> K. P<hi rend="sc">OLK</hi>
                     </signed>
@@ -21686,7 +21686,7 @@
             civilization and Christianity and thus to enable them to enter heaven. Using biblical
             and scientific evidence, he maintains slavery’s necessity for years or centuries to
             come. Abolition in Kentucky now, he asserts, would harm blacks by triggering their sale
-            to harsher masters farther south and “would ... lead to a civil war and a dissolution of
+            to harsher masters farther south and “would . . . lead to a civil war and a dissolution of
             the Union” (<date when="--01-27">January 27</date>), a consequence he blames on Northern
             extremists. He condemns, however, the legislature’s <date when="1849-02">February
               1849</date> decision to reverse an <date when="1833">1833</date> ban on the
@@ -21837,7 +21837,7 @@
                         </hi> of <date when="1849-06-08">June 8, 1849</date>, he most
             likely refers to to an editorial titled “Political Coalitions.” It forecasts, “In a few
             short months, this agitation about slavery will settle itself; and we perceive that the
-            people of California have already moved ... to dispose of the question in their own way.
+            people of California have already moved . . . to dispose of the question in their own way.
             The result of their action in the premises, cannot fail to extinguish all the excitement
             which has grown out of the subject.” The Democratic paper accuses Whigs of hypocrisy for
             criticizing, in the Philadelphia <hi rend="italics">North American and United States


### PR DESCRIPTION
**JIRA Ticket**: [PTC-73](https://jira.lib.utk.edu/projects/PTC/issues/PTC-73)

# What does this Pull Request do?

This pull request tries to normalize ellipses so that they follow the Chicago Manual of Style. 

# What's new?

At our meeting with Michael, he said this was a huge deal.  That's because the book follows the Chicago Manual of Style and ellipses should be separated by spaces.

# How should this be tested?

1. ant
2. import app
3. Review documents to see if ellipses are now separated by spaces (could just look at the Files Changed tab) 

# Interested parties
@mathewjordan 
