### PR TITLE
Hide Chrome Ajax issue.

### DIFF
--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -32,7 +32,6 @@ $(document).ready(function() {
                 dataType: "json",
                 data: params,
                 error: function(xhr, status) {
-                    alert("Not found: " + params);
                     showContent(container, animIn, animOut);
                 },
                 success: function(data) {


### PR DESCRIPTION
**JIRA Ticket**: None

# What does this Pull Request do?
Obfuscates the Chrome Ajax issue related to letters.

# What's new?

In Chrome and Chrome only, the XHR request to ajax.xql is being canceled by the browser. Here is the response Chrome is giving:

```
4932: URL_REQUEST
http://localhost:8080/exist/apps/polk-papers/modules/lib/ajax.xql?doc=polk.xml&root=1.4.2.16&odd=polk.odd&view=div
Start Time: 2018-11-02 07:43:45.695

t=7817 [st=  0] +REQUEST_ALIVE  [dt=110]
                 --> priority = "MEDIUM"
                 --> url = "http://localhost:8080/exist/apps/polk-papers/modules/lib/ajax.xql?doc=polk.xml&root=1.4.2.16&odd=polk.odd&view=div"
t=7817 [st=  0]    NETWORK_DELEGATE_BEFORE_URL_REQUEST  [dt=0]
t=7817 [st=  0]   +URL_REQUEST_START_JOB  [dt=110]
                   --> load_flags = 16384 (MAYBE_USER_GESTURE)
                   --> method = "GET"
                   --> url = "http://localhost:8080/exist/apps/polk-papers/modules/lib/ajax.xql?doc=polk.xml&root=1.4.2.16&odd=polk.odd&view=div"
t=7817 [st=  0]      NETWORK_DELEGATE_BEFORE_START_TRANSACTION  [dt=0]
t=7817 [st=  0]      HTTP_CACHE_GET_BACKEND  [dt=0]
t=7817 [st=  0]      HTTP_CACHE_OPEN_ENTRY  [dt=0]
                     --> net_error = -2 (ERR_FAILED)
t=7817 [st=  0]      HTTP_CACHE_CREATE_ENTRY  [dt=0]
t=7817 [st=  0]      HTTP_CACHE_ADD_TO_ENTRY  [dt=0]
t=7817 [st=  0]     +HTTP_STREAM_REQUEST  [dt=1]
t=7817 [st=  0]        HTTP_STREAM_JOB_CONTROLLER_BOUND
                       --> source_dependency = 4935 (HTTP_STREAM_JOB_CONTROLLER)
t=7818 [st=  1]        HTTP_STREAM_REQUEST_BOUND_TO_JOB
                       --> source_dependency = 4936 (HTTP_STREAM_JOB)
t=7818 [st=  1]     -HTTP_STREAM_REQUEST
t=7818 [st=  1]     +HTTP_TRANSACTION_SEND_REQUEST  [dt=0]
t=7818 [st=  1]        HTTP_TRANSACTION_SEND_REQUEST_HEADERS
                       --> GET /exist/apps/polk-papers/modules/lib/ajax.xql?doc=polk.xml&root=1.4.2.16&odd=polk.odd&view=div HTTP/1.1
                           Host: localhost:8080
                           Connection: keep-alive
                           Accept: application/json, text/javascript, */*; q=0.01
                           X-Requested-With: XMLHttpRequest
                           User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/70.0.3538.77 Chrome/70.0.3538.77 Safari/537.36
                           Referer: http://localhost:8080/exist/apps/polk-papers/polk.xml?root=1.4.2.16&odd=polk.odd&view=div
                           Accept-Encoding: gzip, deflate, br
                           Accept-Language: en-US,en;q=0.9
                           Cookie: JSESSIONID=node0djiv3nek3xhmnmsd3h4mdbha3.node0
t=7818 [st=  1]     -HTTP_TRANSACTION_SEND_REQUEST
t=7818 [st=  1]     +HTTP_TRANSACTION_READ_HEADERS  [dt=109]
t=7818 [st=  1]       +HTTP_STREAM_PARSER_READ_HEADERS  [dt=109]
t=7927 [st=110]          CANCELLED
t=7927 [st=110]   -URL_REQUEST_START_JOB
                   --> net_error = -3 (ERR_ABORTED)
t=7927 [st=110]    URL_REQUEST_DELEGATE_RESPONSE_STARTED  [dt=0]
t=7927 [st=110] -REQUEST_ALIVE
```
This does not fix the issue.  The browser still cancels the request, but we no longer will be showing the alert if we merge this.

My rationale is that if we drop the alert box, the user would not be aware that there is even a problem since the document still loads fine.

# How should this be tested?

1. ant
2. import app
3. open Chrome or Chromium
4. Use the TOC to navigate to letters.

If that page loads fine, we should be good.

# Interested parties
@CanOfBees @mathewjordan 
