### PR TITLE
Address PTC-68: Update letter dateline/salute to display on single line and properly …

### DIFF
--- a/resources/ut-tei/src/scss/tei/layout/_canvas.scss
+++ b/resources/ut-tei/src/scss/tei/layout/_canvas.scss
@@ -26,7 +26,41 @@
     color: $leconte;
     text-decoration: none;
   }
+
+  > section.tei-div2 {
+
+    > * {
+    }
+
+    .tei-opener {
+    }
+
+    .tei-dateline {
+      float: right;
+      margin: 0 0 -1.5rem;
+      padding: 0;
+      max-width: 60%;
+
+      @include respond(xs) {
+        float: none;
+        max-width: 100%;
+        margin: 0 0 1rem;
+      }
+    }
+
+    .tei-salute2 {
+      margin: 0 0 1rem;
+      padding: 0;
+      clear: right;
+      max-width: 40%;
+
+      @include respond(xs) {
+        max-width: 100%;
+      }
+    }
+  }
 }
+
 .tei-opener {
   font-size: 2rem;
 
@@ -36,6 +70,10 @@
     color: $smokeyx;
     font-style: normal;
     margin-bottom: 2rem;
+
+    @include respond(xs) {
+      font-size: $type-4 !important;
+    }
   }
 }
 
@@ -78,6 +116,21 @@
 .tei-dateline {
   margin: 1rem 0;
   text-align: right !important;
+
+  > div,
+  > span {
+    margin-right: 6px !important;
+    display: inline;
+
+    div, span {
+      display: inherit;
+      white-space: normal;
+    }
+
+    &:last-child {
+      margin-right: 0 !important;
+    }
+  }
 
   @extend p.tei-p;
 }


### PR DESCRIPTION
**JIRA Ticket**: [PTC-68](https://jira.lib.utk.edu/browse/PTC-68)

# What does this Pull Request do?

- Adds CSS to render Salute and Dateline elements to single line. 
- Adds CSS to render Dateline elements for _City/Date_ to single line and wrap gracefully. 
- Adds CSS media query to stack above elements at 767px width viewports or lower.

# How should this be tested?

- `Ant` and :arrow_up:
-  View any letter to see that salute and dateline are on same line and appear like the screenshot example below:

<img width="696" alt="salute-dateline-singleline" src="https://user-images.githubusercontent.com/7376450/49093570-5ef1ed80-f232-11e8-9978-22b479bce59d.png">

# Additional Notes:
Breakpoint for mobile and portrait tablets can be tested if window width is brought below 767px.

# Interested parties
@markpbaggett @CanOfBees 
