### PR TITLE
Address PTC-89: Removed unnecessary styling on footer .note class

### DIFF
--- a/resources/ut-tei/src/scss/tei/components/_popover.scss
+++ b/resources/ut-tei/src/scss/tei/components/_popover.scss
@@ -17,8 +17,6 @@
 
 .note {
   border-radius: 100%;
-  display: inline-block;
-  min-width: 10px;
   text-align: center;
   line-height: 100%;
   font-family: $sans !important;


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/browse/PTC-89](https://jira.lib.utk.edu/browse/PTC-89) subtask of https://jira.lib.utk.edu/browse/PTC-87

# What does this Pull Request do?

Removes unnecessary styling on the .note class that was partially causing white-space pockets in document canvas.

# How should this be tested?

1. `Ant` and upload
2. Go to Introduction.
3. Inspect the footnote and see that the `<a class="note" ...` does not have styling for `display: inline-block` or `min-width: 10px`

# Additional Notes:
This is paired with https://jira.lib.utk.edu/browse/PTC-88 being addressed by @markpbaggett 

# Interested parties
@markpbaggett @CanOfBees 
