### PR TITLE
Address PTC-86: Cleanup paragraph implementation, resolve white space...

### DIFF
--- a/resources/ut-tei/src/scss/tei/components/_paragraph.scss
+++ b/resources/ut-tei/src/scss/tei/components/_paragraph.scss
@@ -1,28 +1,39 @@
 p {
+  font-size: 18px !important;
+  line-height: 1.62em;
+  letter-spacing: 0;
+  text-align: justify;
+  text-justify: inter-word;
+  text-indent: $text-indent;
+
+  /*
+   * default implementation of <p>
+   */
   &.tei-p1 {
-    font-size: 18px !important;
+    font-family: $serif-generic;
     line-height: 1.62em;
-    letter-spacing: 0;
-    text-align: justify;
-    text-justify: inter-word;
   }
 
+  /*
+   * @rend=block
+   */
   &.tei-p2 {
-    font-size: 18px !important;
+    font-family: $serif-generic;
     line-height: 1.62em;
-    letter-spacing: 0;
-    text-align: justify;
-    text-justify: inter-word;
     text-indent: 0;
   }
 
+  /*
+   * @rend=right
+   */
   &.tei-p3 {
-    font-size: 18px !important;
+    font-family: $serif-generic;
     line-height: 1.62em;
-    letter-spacing: 0;
     text-align: right;
-    text-justify: inter-word;
+    text-indent: 0;
   }
 
-  text-indent: $text-indent;
+  * {
+    text-indent: 0 !important;
+  }
 }

--- a/resources/ut-tei/src/scss/tei/components/_popover.scss
+++ b/resources/ut-tei/src/scss/tei/components/_popover.scss
@@ -6,12 +6,13 @@
   font-weight: 400;
   padding: 10px 15px !important;
 
-  div, em, span {
+  div, em, span, * {
     display: inline !important;
     margin: 0 !important;
     padding: 0 !important;
     background-color: $smokey !important;
     color: $white !important;
+    letter-spacing: 0;
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/browse/PTC-86](https://jira.lib.utk.edu/browse/PTC-86)

# What does this Pull Request do?

### Note: this Pull Request resolves multiple  lingering issues between related issues. 

It will:

- Resolve items 2, 4, 5 and 6 where indentions were being caused by paragraph styling being extended to other elements.
- Includes force override of all children of paragraphs to not inherit **text-indent** if present in containing element.
- Simplify and describe in commenting the behaviors of paragraph classes.

# How should this be tested?

1. `Ant` and up
2. Items 2, 4, 5, & 6 on [PTC-86](https://jira.lib.utk.edu/browse/PTC-86) will be resolved.
3. Review front matter and any letter containing footnotes. Footnote identifiers should not present whitespace issues any longer regardless of whether `display: inline-block` is present.

# Additional Notes:
Items 1 and 3 will be further addressed when XML is modified with applied `.tei-p2` classes.

# Interested parties
@markpbaggett @CanOfBees 
