### PR TITLE
Address PTC-103

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -5055,11 +5055,22 @@
                     </signed>
         </closer>
         <note>
-                    <p>
-                        <abbr>N.B.</abbr> Direct your letter to <name type="person">James Wirick</name>
-            <name type="place">Paw Paw Lee County Ill</name>
-                    </p>
-                </note>
+            <p rend="block">
+                <abbr>N.B.</abbr> Direct your letter to
+            </p>
+            <p rend="block">
+                <name type="person">James Wirick</name>
+            </p>
+            <p rend="block">
+                <name type="place">Paw Paw</name>
+            </p>
+            <p rend="block">
+                <name type="place">Lee County</name>
+            </p>
+            <p rend="block">
+                <name type="place">Ill</name>
+            </p>
+        </note>
         <postscript>
           <p>
                         <abbr>ALS. DLC–JKP</abbr>. Addressed to <name type="place">Washington City</name>. From


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/projects/PTC/issues/PTC-103](https://jira.lib.utk.edu/projects/PTC/issues/PTC-103)

# What does this Pull Request do?

Address issue of postscript for Wirick 5-13-1848 letter postscript being on a single line. 

# What's new?

* Breaks `<p>` out into five different `<p rend="block">` elements.
* rend="block" attribute aligns the paragraph content flush left.

# How should this be tested?

1. `ant` and import
2. Review Wirick 5-13-1848 and see that postscript is flush left and on five lines. 

# Interested parties
@markpbaggett 
