### PR TITLE
Address PTC 106

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -13484,13 +13484,16 @@
           negros winter clothing a bout ready. We have packed 73 bags of coten.</p>
         <p>The stock all Lcks as well as could be exspected. <name type="person">Mr J. T.
             Leigh</name> has imployed me to at tend to your besness.</p>
-        <p>
-                    <date when="1848-11-08">November 8the 1848</date>
-                    <note place="foot" n="3">This section of
-            the letter is preceded by a table, which begins the second page and is titled “the wats
-            of coten bags made.” It lists the weights of cotton bags numbered 19–73, totaling 27,839
-            pounds.</note>
-                </p>
+        <lb/>
+        <p rend="block">
+            <date when="1848-11-08">November 8the 1848</date>
+            <note place="foot" n="3">
+                This section of
+                the letter is preceded by a table, which begins the second page and is titled “the wats
+                of coten bags made.” It lists the weights of cotton bags numbered 19–73, totaling 27,839
+                pounds.
+            </note>
+        </p>
         <p>Dear sir The back nombers I have sent on to you<note place="foot" n="4">Mairs enclosed,
             in his letter of <date when="--10-09">October 9</date>, a table of the weights of bags
             1–18. They total 9,006 pounds, though Mairs erroneously gives the total as 8,905.</note>


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/projects/PTC/issues/PTC-106](https://jira.lib.utk.edu/projects/PTC/issues/PTC-106)

# What does this Pull Request do?

* Adds `<lb/>` to addendum to letter before second dateline.
* Applies `rend="block"` on second dateline to match source document indention style.

# How should this be tested?

1. `ant` and import
2. Review Mairs 11/8/1848 letter and see that extra exists before second dateline and the dateline is flush left.

# Additional Notes:
The Jira ticket did not address the indention. But, in reviewing the source document, I thought it might have been omitted. No ODD updates necessary for this one.

![image](https://user-images.githubusercontent.com/7376450/51391740-e48e6d00-1b00-11e9-847f-3401bde7df93.png)

# Interested parties
@markpbaggett 
