### PR TITLE
Address PTC-105

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -7596,12 +7596,11 @@
           <signed>A<hi rend="sc">ARON</hi> V. B<hi rend="sc">ROWN</hi>
                     </signed>
         </closer>
-        <note>
-          <p>[c.] July [25]</p>
-          <p>I returned from a trip to Murfreesboro &amp; Shel[b]yville<note place="foot" n="6">Letter inserted to complete probable meaning.</note> &amp; found that I had failed to
-            send off this letter—which I now do however with the assurance that in <name type="person">Rutherford Bedford Williamson</name> &amp; <name type="person">Davidson</name> which I have now canvassd. the Democracy is in a sound &amp; <hi rend="italics">improving</hi> condition. <abbr>AVB</abbr>
-                    </p>
-        </note>
+        <lb/>
+        <p rend="center">[c.] July [25]</p>
+        <p rend="block">I returned from a trip to Murfreesboro &amp; Shel[b]yville<note place="foot" n="6">Letter inserted to complete probable meaning.</note> &amp; found that I had failed to
+        send off this letter—which I now do however with the assurance that in <name type="person">Rutherford Bedford Williamson</name> &amp; <name type="person">Davidson</name> which I have now canvassd. the Democracy is in a sound &amp; <hi rend="italics">improving</hi> condition. <abbr>AVB</abbr>
+            </p>
         <postscript>
           <p>
                         <abbr>ALS. DLC–JKP</abbr>. Probably addressed to <name type="place">Washington

--- a/resources/odd/polk.odd
+++ b/resources/odd/polk.odd
@@ -67,6 +67,7 @@
                     <model predicate="not(@rend)" behaviour="paragraph" useSourceRendition="true"/>
                     <model predicate="@rend='block'" behaviour="paragraph" useSourceRendition="true"/>
                     <model predicate="@rend='right'" behaviour="paragraph" useSourceRendition="true"/>
+                    <model predicate="@rend='center'" behaviour="paragraph" useSourceRendition="true"/>
                 </elementSpec>
                 <elementSpec ident="q" mode="change">
                     <model predicate="not(@rend)" behaviour="inline" useSourceRendition="true"/>

--- a/resources/ut-tei/src/scss/tei/components/_paragraph.scss
+++ b/resources/ut-tei/src/scss/tei/components/_paragraph.scss
@@ -33,6 +33,16 @@ p {
     text-indent: 0;
   }
 
+  /*
+   * @rend=center
+   */
+  &.tei-p4 {
+    font-family: $serif-generic;
+    line-height: 1.62em;
+    text-align: center;
+    text-indent: 0;
+  }
+
   * {
     text-indent: 0 !important;
   }


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/projects/PTC/issues/PTC-105](https://jira.lib.utk.edu/projects/PTC/issues/PTC-105)

# What does this Pull Request do?

Address alignment on date and adds spacing between closer and appended date/letter.

# What's new?

* Adds @rend="center" to polk.odd
* Modify the XML to clean up rendering of appended date and associated paragraph.

# How should this be tested?

1. `ant` and upload.
2. Navigate to letter for Aaron V. Brown July 12, 1848.
3. Review letter and check that it matches Word doc.

# Additional Notes:
I've also added a @rend="block" to the paragraph associated with the date under the closer. This was not noted in the ticket, yet would match the formatting in Word doc.

![image](https://user-images.githubusercontent.com/7376450/51916327-13330000-23ab-11e9-8618-d25eaf709325.png)

# Interested parties
@markpbaggett 
