### PR TITLE
Address PTC-108

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -19370,15 +19370,11 @@
         <opener>
           <title>FROM JOHN DUNCAN</title>
         </opener>
-        <dateline>
-          <address>
-            <addrLine>Southern Telegraph</addrLine>
-          </address>
-        </dateline>
-        <p>The following communication was received at the Columbus [Ga.]<note place="foot" n="1">State here and below identified through content analysis.</note> office, at 8 o’clock,
+        <p rend="center">Southern Telegraph</p>
+        <p rend="right">The following communication was received at the<lb/> Columbus [Ga.]<note place="foot" n="1">State here and below identified through content analysis.</note> office, at 8 o’clock,
           35 min. <abbr>A.M.</abbr>
                 </p>
-        <p>Dated Macon [Ga.] <date when="1849-03-15">March 15th 1849</date>
+        <p rend="right">Dated Macon [Ga.] <date when="1849-03-15">March 15th 1849</date>
                 </p>
         <p>
                     <pb/>


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/projects/PTC/issues/PTC-108](https://jira.lib.utk.edu/projects/PTC/issues/PTC-108)

# What does this Pull Request do?
Updates opener to Duncan 03-15-1849 letter to match Word doc formatting. Note: The centering on the Southern Telegraph paragraph is dependent on [PTC-105](https://github.com/utkdigitalinitiatives/polk-correspondence-app/pull/47) ODD update.

# What's new?
* Removes `dateline>` and `<address>` tags and replaces with generic `<p>`.
* Adds `@rend` to `<p>` to format and match Word document.

# How should this be tested?
1. `ant` and upload.
2. Review Duncan letter to see that matches Word doc.

# Additional Notes:
Note that the _Southern Telegraph_ `<p>` may not appear correct until PTC-105 is merged as this relies on the rend="center" attribute.

# Interested parties
@markpbaggett 
