### PR TITLE
Address PTC-124: Patch date-of-letter declaration so searches don't fail.

### DIFF
--- a/modules/tei-query.xql
+++ b/modules/tei-query.xql
@@ -76,7 +76,11 @@ declare function teis:get-breadcrumbs($config as map(*), $hit as element(), $par
     let $work := root($hit)/*
     let $work-title := nav:get-document-title($config, $work)
     let $date-of-letter := if($hit/tei:dateline/tei:date)
-                           then (', ' || $hit/tei:dateline/tei:date/text())
+                           then (
+                                if($hit/tei:dateline/tei:date/@when)
+                                    then(', ' || $hit/tei:dateline/tei:date/@when)
+                                else($hit/tei:dateline/tei:date)
+                                )
                            else ()
     let $title-of-document := if($hit/tei:opener/tei:title)
                               then ($hit/tei:opener/tei:title/text())

--- a/search.html
+++ b/search.html
@@ -3,7 +3,7 @@
 <head data-template="templates:include" data-template-path="templates/head.html"/>
 <body xmlns:i18n="http://exist-db.org/xquery/i18n">
 <div data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content" data-template-using="body">
-    <div data-template="pages:load">
+    <div>
         <!-- Navigation -->
         <div data-template="templates:include" data-template-path="templates/menu.html"/>
         <!-- Toolbar -->


### PR DESCRIPTION
**JIRA Ticket**: [PTC-124](https://jirautk.atlassian.net/browse/PTC-124)
**JIRA Ticket**: [PTC-126](https://jirautk.atlassian.net/browse/PTC-126)

# What does this Pull Request do?

This seems to address the problem we had this afternoon with some searches failing and also fixes pagination loads on search.html.

# What's new?

This addresses two problems.

1. **Searching for certain phrases**: This problem was caused by looking for tei:dateline/tei:date/text().  If we prefer a tei:dateline/tei:date/@when, then a tei:dateline/tei:date, we get no failures. It's only when text() is specifically called that we have problems.
2.  **Pagination in searching**: Searching has been broken since [this commit](https://github.com/utkdigitalinitiatives/polk-correspondence-app/commit/9a61f202187235815d4b2f69c94ef6aad894ca9f).  We just didn't notice because we never clicked on an additional page to load additional search results.  This partially fixes the problem by not making Exist look for a document at all. Now when you search pagination works as expected as you iterate through results.  This does break PDF generation, but I think we should address that by just statically including a PDF from that link.  That way, we can make it actually look like the Word document too.

# How should this be tested?

1. ant
2. import
3. search for buchanan
4. search for walker
5. search for "Sarah Childress"
6. progress through pagination

# Additional Notes:
Again, PDF generation is broken in search.  I've opened PTC-127 to address this.

# Interested parties
@CanOfBees @mathewjordan 
