### PR TITLE
Address PTC-31 

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -184,7 +184,7 @@
             <name type="person">Sean Benjamin</name>, of the <name type="org">Howard-Tilton Memorial
             Library</name>, <name type="org">Tulane University</name>, <name type="place">New
             Orleans, La.</name>; <name type="person">L. Eileen Parris</name>, of the <name
-            type="org">Virginia Historical Society</name>, <name type="place">Richmond</name>; 
+            type="org">Virginia Historical Society</name>, <name type="place">Richmond</name>;
             <name type="person">Alexandra C. Lane</name>, of the White House Historical Association, Washington, D.C.; <name
             type="person">Susan A. Riggs</name>, of the <name type="org">Earl Gregg Swem
             Library</name>, <name type="org">College of William and Mary</name>, <name type="place"
@@ -274,8 +274,8 @@
           found on a single bookshelf.</p>
         <p>Now we go further. Working with Newfound Press, the digital imprint of <pb/>the <name type="org">University of Tennessee Libraries</name>, the <name type="person">Polk</name>
           Project is making the eleventh president’s letters even easier to find. As of January
-            <date when="2016">2016</date>, the first twelve volumes of the <hi rend="italics">Correspondence</hi> are available, at no charge to the user, at <ref target="http://trace.tennessee.edu/utk_polk/">http://trace.tennessee.edu/utk_polk/</ref>. (They also can be found through our project
-          website, <ref target="http://polkproject.utk.edu">http://polkproject.utk.edu</ref>.)
+            <date when="2016">2016</date>, the first twelve volumes of the <hi rend="italics">Correspondence</hi> are available, at no charge to the user, at <ref rend="external" target="http://trace.tennessee.edu/utk_polk/">http://trace.tennessee.edu/utk_polk/</ref>. (They also can be found through our project
+          website, <ref rend="external" target="http://polkproject.utk.edu">http://polkproject.utk.edu</ref>.)
           Volume 13, only recently published in hardcover, will join them in late <date when="2018">2018</date>. These <abbr>PDF</abbr> volumes include all contents of the hardcover ones,
           plus they are full-text searchable. Users can download them to any device with access to
           the World Wide Web.</p>
@@ -8362,7 +8362,7 @@
             by <name type="person">Peter Peterson</name> and chartered by Wyllie &amp; Egana, of
             <name type="place">New Orleans</name>, agents for Rubio, Brother &amp; <abbr>Co.</abbr>, a firm
             of Spaniards in <name type="place">Mexico</name>. Ownership of at least the cotton
-            transferred, en route, to Barron, Forbes &amp; <abbr>Co.</abbr>, a British firm in <name type="place">Tepic, Mexico</name>. On <date when="1847-04-07">April 7, 1847</date>, 
+            transferred, en route, to Barron, Forbes &amp; <abbr>Co.</abbr>, a British firm in <name type="place">Tepic, Mexico</name>. On <date when="1847-04-07">April 7, 1847</date>,
             <name type="person">Cmdr. John A. Montgomery</name>, of the <abbr>USS</abbr> <hi rend="italics">Portsmouth</hi>, seized the ship and cargo at <name type="place">San José de Cabo, Baja California,
               Mexico</name>. He charged the owners, charterers, and captain with the intention illegally to
             deliver the cargo to <name type="place">San Blas, Mexico</name>. After the <abbr>U.S.</abbr> Court of Admiralty. . . .</note>

--- a/data/polk.xml
+++ b/data/polk.xml
@@ -8362,7 +8362,7 @@
             by <name type="person">Peter Peterson</name> and chartered by Wyllie &amp; Egana, of
             <name type="place">New Orleans</name>, agents for Rubio, Brother &amp; <abbr>Co.</abbr>, a firm
             of Spaniards in <name type="place">Mexico</name>. Ownership of at least the cotton
-            transferred, en route, to Barron, Forbes &amp; <abbr>Co.</abbr>, a British firm in <name type="place">Tepic, Mexico</name>. On <date when="1847-04-07">April 7, 1847</date>,
+            transferred, en route, to Barron, Forbes &amp; <abbr>Co.</abbr>, a British firm in <name type="place">Tepic, Mexico</name>. On <date when="1847-04-07">April 7, 1847</date>, 
             <name type="person">Cmdr. John A. Montgomery</name>, of the <abbr>USS</abbr> <hi rend="italics">Portsmouth</hi>, seized the ship and cargo at <name type="place">San José de Cabo, Baja California,
               Mexico</name>. He charged the owners, charterers, and captain with the intention illegally to
             deliver the cargo to <name type="place">San Blas, Mexico</name>. After the <abbr>U.S.</abbr> Court of Admiralty. . . .</note>

--- a/resources/odd/polk.odd
+++ b/resources/odd/polk.odd
@@ -33,15 +33,18 @@
     </teiHeader>
     <text>
         <body>
-            <schemaSpec start="TEI teiCorpus" ident="polk" source="teipublisher.odd"> 
+            <schemaSpec start="TEI teiCorpus" ident="polk" source="teipublisher.odd">
                 <elementSpec ident="ref" mode="change">
                     <model predicate="not(@target)" behaviour="inline"/>
                     <model predicate="not(text())" behaviour="link">
                         <param name="content" value="@target"/>
                         <param name="uri" value="@target"/>
                     </model>
-                    <model behaviour="link">
+                    <model predicate="not(@rend)" behaviour="link">
                         <param name="link" value="concat('?id=', @target)"/>
+                    </model>
+                    <model predicate="@rend='external'" behaviour="link">
+                        <param name="link" value="@target"/>
                     </model>
                 </elementSpec>
             <elementSpec ident="pb" mode="change">


### PR DESCRIPTION
**JIRA Ticket**: [PTC-31](https://jirautk.atlassian.net/projects/PTC/issues/PTC-31)

# What does this Pull Request do?

Updates the ODD and XML so that `<ref>` tags in XML are not globally rendered as internal references. 

# What's new?

Previously all `<ref>` tags were rendered as links with concatenated `?id=` strings prefixing the the href attribute in the rendered `<a>`. This fix updates the ODD to allow for external links to render properly without this concat function using a predicate where the `@rend='external'` attribute is present.

* Updates ODD for ref elementSpec.
* Updates external links in the XML to contain the `@rend='external'` attribute.

# How should this be tested?

1. `ant` and upload.
2. Navigate to Introduction (Page 3).
3. Scroll down and test links to 6th paragraph and test links to http://trace.tennessee.edu/utk_polk/ and http://polkproject.utk.edu.
4. If external links work correctly, the override rule for `@rend='external'` attribute works correctly.
4. Click Menu in bottom left..
5. Click Letters.
6. Click any letter.
7. If the letter expected displays then links work correctly for internal reference using global rule.

**Does this modify polk.xml? If so, is the document valid?**

Yes, and yes.

# Additional Notes:

This one had been sitting out there for a while. It seemed like an easy fix now that we have a hand on adjusting the ODD.

# Interested parties
@markpbaggett @CanOfBees 
