### PR TITLE
Address PTC-133 (Polk on Safari)

### DIFF
--- a/resources/ut-tei/src/scripts/teiEvents.js
+++ b/resources/ut-tei/src/scripts/teiEvents.js
@@ -75,9 +75,9 @@ function buildLandingPage () {
         landingPage.classList.add('polk-logos');
         landingPage.classList.add('row');
         landingPage.innerHTML =
-            "<div class='col-sm-4 col-xs-12'><a href='https://www.archives.gov/nhprc' target='_blank'><img src='" + LogoNHPRC + "' alt='National Archives: National Historical Publications & Records Commission'/></a></div>" +
-            "<div class='col-sm-4 col-xs-12'><a href='https://www.neh.gov/' target='_blank'><img src='" + LogoNEH + "' alt='National Endowment for the Humanities'/></a></div>" +
-            "<div class='col-sm-4 col-xs-12'><a href='https://newfoundpress.utk.edu/' target='_blank'><img src='" + LogoNewfoundPress + "' alt='Newfound Press'/></a></div>"
+            "<div class='col-md-4 col-sm-12'><a href='https://www.archives.gov/nhprc' target='_blank'><img src='" + LogoNHPRC + "' alt='National Archives: National Historical Publications & Records Commission'/></a></div>" +
+            "<div class='col-md-4 col-sm-12'><a href='https://www.neh.gov/' target='_blank'><img src='" + LogoNEH + "' alt='National Endowment for the Humanities'/></a></div>" +
+            "<div class='col-md-4 col-sm-12'><a href='https://newfoundpress.utk.edu/' target='_blank'><img src='" + LogoNewfoundPress + "' alt='Newfound Press'/></a></div>"
         ;
         documentPaneContent.appendChild(landingPage);
     }

--- a/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
+++ b/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
@@ -2,7 +2,7 @@
   margin-top: 123px;
   margin-bottom: 76px;
 
-  @include respond(xs, sm, md, lg, xl) {
+  @include respond(sm, md, lg, xl) {
     flex-wrap: nowrap !important;
   }
 

--- a/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
+++ b/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
@@ -1,7 +1,10 @@
 .content .polk-logos {
   margin-top: 123px;
   margin-bottom: 76px;
-
+  
+  /*
+   * safari specific fix for flex-wrap issue with bootstrap.
+   */
   @include respond(sm, md, lg, xl) {
     flex-wrap: nowrap !important;
   }

--- a/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
+++ b/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
@@ -2,6 +2,11 @@
   margin-top: 123px;
   margin-bottom: 76px;
 
+  @include respond(xs, sm, md, lg, xl) {
+    flex-wrap: nowrap !important;
+  }
+
+
   > div[class*=' col-'] {
     text-align: center;
     position: relative;

--- a/resources/ut-tei/src/scss/tei/layout/_container.scss
+++ b/resources/ut-tei/src/scss/tei/layout/_container.scss
@@ -34,3 +34,9 @@ body {
     background-color: $white;
   }
 }
+
+@include respond(sm, md, lg, xl) {
+  main.row {
+    flex-wrap: nowrap !important;
+  }
+}

--- a/resources/ut-tei/src/scss/tei/layout/_container.scss
+++ b/resources/ut-tei/src/scss/tei/layout/_container.scss
@@ -35,6 +35,9 @@ body {
   }
 }
 
+/*
+ * safari specific fix for flex-wrap issue with bootstrap.
+ */
 @include respond(sm, md, lg, xl) {
   main.row {
     flex-wrap: nowrap !important;

--- a/resources/ut-tei/src/scss/tei/layout/_search.scss
+++ b/resources/ut-tei/src/scss/tei/layout/_search.scss
@@ -73,6 +73,7 @@
     p {
       font-size: 15px !important;
       text-align: left !important;
+      text-indent: 0 !important;
     }
 
     ul {

--- a/search.html
+++ b/search.html
@@ -42,133 +42,7 @@
             </nav>
             <div class="container">
                 <main xmlns:i18n="http://exist-db.org/xquery/i18n" class="row search">
-                <div class="col-md-4 col-md-push-8">
-                    <div class="search-help">
-                        <h3 class="search-column-heading">Search Guide</h3>
-                        <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
-                                    <h4 class="panel-title">
-                                        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne"
-                                           aria-expanded="true" aria-controls="collapseOne">
-                                            Multi-word, Exact Phrase Searching
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel"
-                                     aria-labelledby="headingOne">
-                                    <div class="panel-body">
-                                        <p>Wrapping quote characters can be included to narrow results when searching for locations, names of persons, or other exact phrases.</p>
-                                        <h5>Examples</h5>
-                                        <ul>
-                                            <li><strong>"San Francisco"</strong> will yield results where the exact phrase, <em>San Francisco</em>, exists, excluding results that may also include the word <em>San</em>.</li>
-                                            <li><strong>"Missouri Compromise"</strong> will yield more specific results than <em>Missouri Compromise</em>, excluding results that may also include the use of <em>Missouri</em> and <em>Compromise</em> independent of each other.</li>
-                                            <li><strong>"James Buchanan"</strong> will yield more specific results than <em>James Buchanan</em>, excluding results that may also include other persons with a first name <em>James</em>.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingTwo">
-                                    <h4 class="panel-title">
-                                        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
-                                           href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                                            Wildcard Searching
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel"
-                                     aria-labelledby="headingTwo">
-                                    <div class="panel-body">
-                                        <p>Using asterisks can expand results to include words that include a portion of the substring being searched.</p>
-                                        <h5>Examples</h5>
-                                        <ul>
-                                            <li><strong class="search-help-subhead">Suffix searching:</strong> searching <strong>annex*</strong> would include results where the word <em>annexation</em> and <em>annexed</em> are also included.</li>
-                                            <li><strong class="search-help-subhead">Prefix searching:</strong> searching <strong>*charge</strong> would include results where the word <em>discharge</em> is also included.</li>
-                                            <li><strong class="search-help-subhead">Words that contain substrings:</strong> Searching for <strong>*slave*</strong> would also include results where the word <em>slaves</em>, <em>enslaved</em> and <em>slavery</em> are mentioned.</li>
-                                            <li><strong class="search-help-subhead">Single character wildcard searches:</strong> Searching for <strong>te?t</strong> will include results where the term <em>test</em> or <em>text</em> appears.</li>
-                                            <li><strong class="search-help-subhead">Multi character wildcard searches:</strong> Searching for <strong>ch*ss</strong> will include results where the term <em>Childress</em> or <em>cheapness</em> appear.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingThree">
-                                    <h4 class="panel-title">
-                                        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
-                                           href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
-                                            Boolean Operators
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapseThree" class="panel-collapse collapse" role="tabpanel"
-                                     aria-labelledby="headingThree">
-                                    <div class="panel-body">
-                                        <p>The following boolean operators can be used to refine your search:  AND, OR, NOT, +, and -.</p>
-                                        <h5>Examples</h5>
-                                        <ul>
-                                            <li><strong>Eliza Caldwell AND mule</strong> will yield results where both the term <em>Caldwell</em> and the term <em>mule</em> are present in the document.</li>
-                                            <li><strong>Caldwell OR mule</strong> will yield results where the term <em>Caldwell</em> or the term <em>mule</em> are present in the document.</li>
-                                            <li><strong>Caldwell NOT mule</strong> will yield results where the term <em>Caldwell</em> is present in the document but not the term <em>mule</em>.</li>
-                                            <li>The <strong>(+)</strong>, or required operator, requires that the term after the <em>“+”</em> symbol exist somewhere in the document. (i.e. <strong>+Caldwell mule</strong>)</li>
-                                            <li>The <strong>(-)</strong>, or prohibit operator, excludes documents that include the term or phrase that appears after the <em>“-”</em> symbol. (i.e. <strong>Caldwell -mule</strong>)</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingFour">
-                                    <h4 class="panel-title">
-                                        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
-                                           href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
-                                            Groupings
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapseFour" class="panel-collapse collapse" role="tabpanel"
-                                     aria-labelledby="headingFour">
-                                    <div class="panel-body">
-                                        <p>Parentheses around groupings can be used to control the boolean logic of a query.</p>
-                                        <h5>Examples</h5>
-                                        <ul>
-                                            <li><strong>(Mississippi OR “New Orleans”) AND Walker</strong> will return results where the term <em>Mississippi</em> or the phrase <em>New Orleans</em> is present and the term <em>Walker</em> is required.</li>
-                                            <li><strong>(Mississippi AND “New Orleans”) OR Walker</strong> will return results where the term <em>Mississippi</em> and the phrase <em>New Orleans</em> are present but the term <em>Walker</em> is optional.</li>
-                                            <li><strong>(Mississippi OR “New Orleans”) NOT Walker</strong> will return results where the term <em>Mississippi</em> or the phrase <em>New Orleans</em> is present but the term <em>Walker</em> is prohibited.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingFive">
-                                    <h4 class="panel-title">
-                                        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
-                                           href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
-                                            Escape Characters
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapseFive" class="panel-collapse collapse" role="tabpanel"
-                                     aria-labelledby="headingFive">
-                                    <div class="panel-body">
-                                        <p>There are several characters that have special meaning that must be escaped in
-                                            order to include them in searches. These include: + - &amp;&amp; || ! ( ) { } [
-                                            ] ^ " ~ * ? : \. To include these in a search, use a <strong>\</strong> before
-                                            the character.</p>
-                                        <h5>Examples</h5>
-                                        <ul>
-                                            <li><strong>"Imm\[e\]diately"</strong> will return results where the exact term
-                                                <em>"Imm\[e\]diately"</em> is present.</li>
-                                            <li><strong>Imm\[e\]diately</strong> will return results where any parts
-                                                of the term <em>Imm\[e\]diately</em> is present.</li>
-                                            <li><strong>Imm[e]diately</strong> will return an error or no results.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-8 col-md-pull-4">
+                <div class="col-md-8 col-sm-12">
                     <h3 class="search-column-heading">Search Results</h3>
                     <div class="panel panel-default">
                         <div class="search:query">
@@ -208,6 +82,132 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-md-4 col-sm-12">
+                        <div class="search-help">
+                            <h3 class="search-column-heading">Search Guide</h3>
+                            <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingOne">
+                                        <h4 class="panel-title">
+                                            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne"
+                                               aria-expanded="true" aria-controls="collapseOne">
+                                                Multi-word, Exact Phrase Searching
+                                            </a>
+                                        </h4>
+                                    </div>
+                                    <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel"
+                                         aria-labelledby="headingOne">
+                                        <div class="panel-body">
+                                            <p>Wrapping quote characters can be included to narrow results when searching for locations, names of persons, or other exact phrases.</p>
+                                            <h5>Examples</h5>
+                                            <ul>
+                                                <li><strong>"San Francisco"</strong> will yield results where the exact phrase, <em>San Francisco</em>, exists, excluding results that may also include the word <em>San</em>.</li>
+                                                <li><strong>"Missouri Compromise"</strong> will yield more specific results than <em>Missouri Compromise</em>, excluding results that may also include the use of <em>Missouri</em> and <em>Compromise</em> independent of each other.</li>
+                                                <li><strong>"James Buchanan"</strong> will yield more specific results than <em>James Buchanan</em>, excluding results that may also include other persons with a first name <em>James</em>.</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingTwo">
+                                        <h4 class="panel-title">
+                                            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
+                                               href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                                                Wildcard Searching
+                                            </a>
+                                        </h4>
+                                    </div>
+                                    <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel"
+                                         aria-labelledby="headingTwo">
+                                        <div class="panel-body">
+                                            <p>Using asterisks can expand results to include words that include a portion of the substring being searched.</p>
+                                            <h5>Examples</h5>
+                                            <ul>
+                                                <li><strong class="search-help-subhead">Suffix searching:</strong> searching <strong>annex*</strong> would include results where the word <em>annexation</em> and <em>annexed</em> are also included.</li>
+                                                <li><strong class="search-help-subhead">Prefix searching:</strong> searching <strong>*charge</strong> would include results where the word <em>discharge</em> is also included.</li>
+                                                <li><strong class="search-help-subhead">Words that contain substrings:</strong> Searching for <strong>*slave*</strong> would also include results where the word <em>slaves</em>, <em>enslaved</em> and <em>slavery</em> are mentioned.</li>
+                                                <li><strong class="search-help-subhead">Single character wildcard searches:</strong> Searching for <strong>te?t</strong> will include results where the term <em>test</em> or <em>text</em> appears.</li>
+                                                <li><strong class="search-help-subhead">Multi character wildcard searches:</strong> Searching for <strong>ch*ss</strong> will include results where the term <em>Childress</em> or <em>cheapness</em> appear.</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingThree">
+                                        <h4 class="panel-title">
+                                            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
+                                               href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                                                Boolean Operators
+                                            </a>
+                                        </h4>
+                                    </div>
+                                    <div id="collapseThree" class="panel-collapse collapse" role="tabpanel"
+                                         aria-labelledby="headingThree">
+                                        <div class="panel-body">
+                                            <p>The following boolean operators can be used to refine your search:  AND, OR, NOT, +, and -.</p>
+                                            <h5>Examples</h5>
+                                            <ul>
+                                                <li><strong>Eliza Caldwell AND mule</strong> will yield results where both the term <em>Caldwell</em> and the term <em>mule</em> are present in the document.</li>
+                                                <li><strong>Caldwell OR mule</strong> will yield results where the term <em>Caldwell</em> or the term <em>mule</em> are present in the document.</li>
+                                                <li><strong>Caldwell NOT mule</strong> will yield results where the term <em>Caldwell</em> is present in the document but not the term <em>mule</em>.</li>
+                                                <li>The <strong>(+)</strong>, or required operator, requires that the term after the <em>“+”</em> symbol exist somewhere in the document. (i.e. <strong>+Caldwell mule</strong>)</li>
+                                                <li>The <strong>(-)</strong>, or prohibit operator, excludes documents that include the term or phrase that appears after the <em>“-”</em> symbol. (i.e. <strong>Caldwell -mule</strong>)</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingFour">
+                                        <h4 class="panel-title">
+                                            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
+                                               href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+                                                Groupings
+                                            </a>
+                                        </h4>
+                                    </div>
+                                    <div id="collapseFour" class="panel-collapse collapse" role="tabpanel"
+                                         aria-labelledby="headingFour">
+                                        <div class="panel-body">
+                                            <p>Parentheses around groupings can be used to control the boolean logic of a query.</p>
+                                            <h5>Examples</h5>
+                                            <ul>
+                                                <li><strong>(Mississippi OR “New Orleans”) AND Walker</strong> will return results where the term <em>Mississippi</em> or the phrase <em>New Orleans</em> is present and the term <em>Walker</em> is required.</li>
+                                                <li><strong>(Mississippi AND “New Orleans”) OR Walker</strong> will return results where the term <em>Mississippi</em> and the phrase <em>New Orleans</em> are present but the term <em>Walker</em> is optional.</li>
+                                                <li><strong>(Mississippi OR “New Orleans”) NOT Walker</strong> will return results where the term <em>Mississippi</em> or the phrase <em>New Orleans</em> is present but the term <em>Walker</em> is prohibited.</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingFive">
+                                        <h4 class="panel-title">
+                                            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
+                                               href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+                                                Escape Characters
+                                            </a>
+                                        </h4>
+                                    </div>
+                                    <div id="collapseFive" class="panel-collapse collapse" role="tabpanel"
+                                         aria-labelledby="headingFive">
+                                        <div class="panel-body">
+                                            <p>There are several characters that have special meaning that must be escaped in
+                                                order to include them in searches. These include: + - &amp;&amp; || ! ( ) { } [
+                                                ] ^ " ~ * ? : \. To include these in a search, use a <strong>\</strong> before
+                                                the character.</p>
+                                            <h5>Examples</h5>
+                                            <ul>
+                                                <li><strong>"Imm\[e\]diately"</strong> will return results where the exact term
+                                                    <em>"Imm\[e\]diately"</em> is present.</li>
+                                                <li><strong>Imm\[e\]diately</strong> will return results where any parts
+                                                    of the term <em>Imm\[e\]diately</em> is present.</li>
+                                                <li><strong>Imm[e]diately</strong> will return an error or no results.</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
             </main>
             </div>
         </section>


### PR DESCRIPTION
**JIRA Ticket**: [PTC-133](https://jirautk.atlassian.net/projects/PTC/issues/PTC-133)

# What does this Pull Request do?

Resolves general flex box wrapping issue noted by @markpbaggett in Safari.

# What's new?

* Updates flex-wrap in CSS for `main.row` selectors at higher breakpoints.
* Updates flex-wrap in CSS for logos in front matter.
* Updates DOM render order of search page columns to make results first.
* Updates indent issue on search guide paragraph.

# How should this be tested?

1. `ant` and up that
2. Open **Safari**
3. Review front matter logos at http://localhost:8080/exist/apps/polk-papers/polk.xml?odd=polk.odd and make sure logos align in a single row at breakpoints above 768px.
4. Review search results page and make sure floating divs align in a single row at breakpoints above 576px.

# Interested parties
@saltar 
