### PR TITLE
Address PTC-132

### DIFF
--- a/resources/ut-tei/src/scripts/teiEvents.js
+++ b/resources/ut-tei/src/scripts/teiEvents.js
@@ -28,25 +28,16 @@ function checkAdmin() {
 
 window.addEventListener('load', runLoad, false);
 
-
-// reset has after login to avoid looping
+// reset after login to avoid looping dialog
 function loginActions() {
     window.location.hash = '#loginSent';
 }
 
-const el = document.getElementById("loginSubmit");
-window.addEventListener('click', loginActions, false);
+let loginMenuButton = document.getElementById('login-menu-button');
 
-
-// scours for core TEI login button, if it exists, hides ugly admin nav
-let loginExists = document.getElementById("login");
-if (loginExists) {
-    // let navbar = document.getElementsByClassName('navbar');
-    // let iterateNav = Array.prototype.filter.call(navbar, function(nav){
-    //     nav.setAttribute('style', 'display:none !important;');
-    // });
+if (loginMenuButton !== null) {
+    loginActions()
 }
-
 
 /*
  * build logos on landing page

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -4,7 +4,7 @@
         <div class="container" data-template="browse:fix-links">
             <div class="navbar-collapse collapse" id="navbar-collapse-1">
                 <ul class="nav navbar-nav">
-                    <li class="dropdown" data-template="browse:show-if-logged-in">
+                    <li id="login-menu-button" class="dropdown" data-template="browse:show-if-logged-in">
                         <a href="#" class="dropdown-toggle tp-menu-item" data-toggle="dropdown" aria-haspopup="true"
                            role="button" aria-expanded="false" title="i18n(admin)">
                             <div>


### PR DESCRIPTION
**JIRA Ticket**: [PTC-132](https://jirautk.atlassian.net/projects/PTC/issues/PTC-132)

# What does this Pull Request do?

Previously, an event listener existed that looked for ANY click in the document and sent a #loginSent hash to the URL. Exist saw this is and would reload the page, causing a flickering effect.

This pull request updates my method from a listener to look for a DOM selector  of `#login-menu-button` and fire the function that should send the #loginSent hash. This hash is necessary to avoid the modal dialog from looping and constantly displaying even after a successful login.

# What's new?

* Update custom vanilla JS that helps us login to eXide from the browser.

# How should this be tested?

1. `ant` and up
2. Go to http://localhost:8080/exist/apps/polk-papers/polk.xml
3. Click anywhere on screen and be sure that a `#loginSent` hash is not appended to the URL
4. Type http://localhost:8080/exist/apps/polk-papers/polk.xml#login to view login dialog
5. Login with credentials
6. Login dialog should go away and a `#loginSent` has will show in the URL. Note: a small flicker may occur here, but I think this is minor as it is not shown to anonymous users.

# Additional Notes:
Small bug I noticed. I'm not sure if this is _flicker_ others have noted.

# Interested parties
@markpbaggett @saltar (saltar can do this but needs to be able to login in his localhost admin)
