### PR TITLE
Add logo thumbnail and credit above sponsor logos.

### DIFF
--- a/resources/ut-tei/src/scripts/teiEvents.js
+++ b/resources/ut-tei/src/scripts/teiEvents.js
@@ -62,6 +62,14 @@ if (urlParams.has('root')) {
 function buildLandingPage () {
     if (document.getElementById('document-pane')) {
         const documentPaneContent = document.getElementById('document-pane').getElementsByClassName('content')[0];
+        const photoCredit = document.createElement('div');
+        photoCredit.classList.add('polk-photo-credit');
+        photoCredit.classList.add('row');
+        photoCredit.innerHTML =
+            "<div class='col-md-2 col-lg-1'><a href='https://www.whitehousehistory.org/photos/james-k-polk' target='_blank'><img src='https://newfoundpress.utk.edu/wp-content/uploads/2019/03/James-Polk-228x300.jpg' alt='Portrait of James K. Polk&#65279; by by George P. A. Healy (1858)' srcset='https://newfoundpress.utk.edu/wp-content/uploads/2019/03/James-Polk-228x300.jpg 228w, https://newfoundpress.utk.edu/wp-content/uploads/2019/03/James-Polk-768x1012.jpg 768w, https://newfoundpress.utk.edu/wp-content/uploads/2019/03/James-Polk-777x1024.jpg 777w, https://newfoundpress.utk.edu/wp-content/uploads/2019/03/James-Polk.jpg 1040w' sizes='(max-width: 228px) 100vw, 228px'/></a></div>" +
+            "<div class='col-md-8 col-lg-4'>" +
+            "<p><a href='https://www.whitehousehistory.org/photos/james-k-polk' target='_blank'>Portrait by George P. A. Healy (1858) <br/> <em>Credit: White House Collection/White House Historical Association.</em></a></p>" +
+            "</div>";
         const landingPage = document.createElement('div');
         landingPage.classList.add('polk-logos');
         landingPage.classList.add('row');
@@ -70,6 +78,7 @@ function buildLandingPage () {
             "<div class='col-md-4 col-sm-12'><a href='https://www.neh.gov/' target='_blank'><img src='" + LogoNEH + "' alt='National Endowment for the Humanities'/></a></div>" +
             "<div class='col-md-4 col-sm-12'><a href='https://newfoundpress.utk.edu/' target='_blank'><img src='" + LogoNewfoundPress + "' alt='Newfound Press'/></a></div>"
         ;
+        documentPaneContent.appendChild(photoCredit);
         documentPaneContent.appendChild(landingPage);
     }
 }

--- a/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
+++ b/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
@@ -1,7 +1,7 @@
 .content .polk-logos {
-  margin-top: 123px;
+  margin-top: $golden-ratio-4;
   margin-bottom: 76px;
-  
+
   /*
    * safari specific fix for flex-wrap issue with bootstrap.
    */
@@ -35,5 +35,30 @@
     max-height: 200px;
     min-width: auto;
     min-height: auto;
+  }
+}
+
+.polk-photo-credit {
+  margin-top: $golden-ratio-5;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-content: space-around;
+
+  img {
+    max-width: 100% !important;
+    min-width: 0 !important;
+
+    @include respond(xs) {
+      margin-bottom: $golden-ratio-3;
+    }
+  }
+
+  p {
+    text-indent: 0 !important;
+    font-size: 15px !important;
+    text-align: left;
+    word-break: keep-all;
+    hyphens: none;
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: [PTC-139](https://jirautk.atlassian.net/projects/PTC/issues/PTC-139)

# What does this Pull Request do?

Adds a thumbnail and photo credit above the sponsor logos.

![image](https://user-images.githubusercontent.com/7376450/54827155-c15e7600-4c87-11e9-8122-31f2d7cb5f7a.png)

# What's new?

* Adds additional section above sponsor logos containing an un-cropped thumbnail and credit.
* Links credit and thumbnail to [original source](https://www.whitehousehistory.org/photos/james-k-polk)

# How should this be tested?

1. `ant` and upload
2. Review Sponsored By page and make sure thumbnail and credit are rendering.

# Interested parties
@markpbaggett 
