### PR TITLE
Address PTC-146

### DIFF
--- a/data/polk.xml
+++ b/data/polk.xml
@@ -16,7 +16,7 @@
       <publicationStmt>
         <publisher>Newfound Press</publisher>
         <pubPlace>Knoxville, Tennessee</pubPlace>
-        <date when="2017">2017</date>
+        <date when="2019">2019</date>
       </publicationStmt>
       <sourceDesc>
         <p>Document created in electronic form.</p>
@@ -39,7 +39,7 @@
           <name type="assistant_editor">Bradley J. Nichols</name>
         </byline>
         <docImprint rend="center">
-          <date when="2017">2017</date>
+          <date when="2019">2019</date>
           <publisher>Newfound Press</publisher>
           <pubPlace>Knoxville, Tennessee</pubPlace>
         </docImprint>
@@ -62,12 +62,6 @@
         <p rend="block">
                     <name type="org">Tennessee Historical Commission</name>
                 </p>
-        <!--<figure>-->
-          <!--<graphic url="nationalarchives.jpg"/>-->
-        <!--</figure>-->
-        <!--<figure>-->
-          <!--<graphic url="humanities.jpg"/>-->
-        <!--</figure>-->
       </div>
       <div type="ack">
         <pb/>

--- a/resources/ut-tei/src/scripts/teiEvents.js
+++ b/resources/ut-tei/src/scripts/teiEvents.js
@@ -87,6 +87,16 @@ function buildLandingPage () {
     if (window.document.getElementById('document-pane')) {
         let documentPaneContent = window.document.getElementById('document-pane').getElementsByClassName('content')[0];
 
+        let byline = window.document.createElement('div');
+        byline.classList.add('polk-editor-publisher');
+        byline.classList.add('row');
+        byline.innerHTML =
+            "<div class='col-md-12'>" +
+            "<p class='tei-p2 editor'>Michael David Cohen</p>" +
+            "<p class='tei-p2 assistant-editor'>Bradley J. Nichols</p>" +
+            "<p class='tei-p2 publisher'>2019 Newfound Press Knoxville, Tennessee</p>"
+            "</div>";
+
         let photoCredit = window.document.createElement('div');
         photoCredit.classList.add('polk-photo-credit');
         photoCredit.classList.add('row');
@@ -105,18 +115,8 @@ function buildLandingPage () {
             "<div class='col-md-4 col-sm-12'><a href='https://newfoundpress.utk.edu/' target='_blank'><img src='" + LogoNewfoundPress + "' alt='Newfound Press'/></a></div>"
         ;
 
+        documentPaneContent.prepend(byline);
         documentPaneContent.append(photoCredit);
         documentPaneContent.append(landingPage);
     }
 }
-
-
-{/*<byline>*/}
-    {/*<name type="editor">MICHAEL DAVID COHEN</name>*/}
-    {/*<name type="assistant_editor">Bradley J. Nichols</name>*/}
-{/*</byline>*/}
-{/*<docImprint rend="center">*/}
-    {/*<date when="2019">2019</date>*/}
-{/*<publisher>Newfound Press</publisher>*/}
-{/*<pubPlace>Knoxville, Tennessee</pubPlace>*/}
-{/*</docImprint>*/}

--- a/resources/ut-tei/src/scripts/teiEvents.js
+++ b/resources/ut-tei/src/scripts/teiEvents.js
@@ -5,6 +5,7 @@
 function runLoad() {
     doModal();
     checkAdmin();
+    checkPolkParams();
 }
 
 // set modal popup on URL visit w/ #loginDialog
@@ -48,21 +49,45 @@ import LogoNEH from '../media/custom/NEH_h-logo_03_all-black.svg';
 import LogoNewfoundPress from '../media/custom/newfound-press-logo.svg';
 
 const urlParams = new URLSearchParams(window.location.search);
-const defaultRoot = '1.4.2.4';
+const defaultRoot = '2.4.2.4';
+const pushState = history.pushState;
 
-if (urlParams.has('root')) {
-    let root = urlParams.get('root');
-    if (root === defaultRoot) {
-        buildLandingPage();
+history.pushState = function () {
+    pushState.apply(history, arguments);
+    fireEvents('pushState', arguments);  // Some event-handling function
+};
+
+function fireEvents(state, arguements) {
+    let urlString = arguements[2];
+    let urlSanitized = urlString.replace('polk.xml','');
+    let updateUrlParams = new URLSearchParams(urlSanitized);
+    checkPolkParams(updateUrlParams, 'dynamic');
+}
+
+function checkPolkParams (url = urlParams, method = 'default') {
+    if (url.has('root') || url.has('id')) {
+        let root = url.get('root');
+        if (root === defaultRoot) {
+            if (method !== 'dynamic') {
+                buildLandingPage();
+            } else {
+                location.reload();
+            }
+        }
+    } else {
+        if (method !== 'dynamic') {
+            buildLandingPage();
+        } else {
+            location.reload();
+        }
     }
-} else {
-    buildLandingPage();
 }
 
 function buildLandingPage () {
-    if (document.getElementById('document-pane')) {
-        const documentPaneContent = document.getElementById('document-pane').getElementsByClassName('content')[0];
-        const photoCredit = document.createElement('div');
+    if (window.document.getElementById('document-pane')) {
+        let documentPaneContent = window.document.getElementById('document-pane').getElementsByClassName('content')[0];
+
+        let photoCredit = window.document.createElement('div');
         photoCredit.classList.add('polk-photo-credit');
         photoCredit.classList.add('row');
         photoCredit.innerHTML =
@@ -70,7 +95,8 @@ function buildLandingPage () {
             "<div class='col-md-8 col-lg-4'>" +
             "<p><a href='https://www.whitehousehistory.org/photos/james-k-polk' target='_blank'>Portrait by George P. A. Healy (1858) <br/> <em>Credit: White House Collection/White House Historical Association.</em></a></p>" +
             "</div>";
-        const landingPage = document.createElement('div');
+
+        let landingPage = window.document.createElement('div');
         landingPage.classList.add('polk-logos');
         landingPage.classList.add('row');
         landingPage.innerHTML =
@@ -78,7 +104,19 @@ function buildLandingPage () {
             "<div class='col-md-4 col-sm-12'><a href='https://www.neh.gov/' target='_blank'><img src='" + LogoNEH + "' alt='National Endowment for the Humanities'/></a></div>" +
             "<div class='col-md-4 col-sm-12'><a href='https://newfoundpress.utk.edu/' target='_blank'><img src='" + LogoNewfoundPress + "' alt='Newfound Press'/></a></div>"
         ;
-        documentPaneContent.appendChild(photoCredit);
-        documentPaneContent.appendChild(landingPage);
+
+        documentPaneContent.append(photoCredit);
+        documentPaneContent.append(landingPage);
     }
 }
+
+
+{/*<byline>*/}
+    {/*<name type="editor">MICHAEL DAVID COHEN</name>*/}
+    {/*<name type="assistant_editor">Bradley J. Nichols</name>*/}
+{/*</byline>*/}
+{/*<docImprint rend="center">*/}
+    {/*<date when="2019">2019</date>*/}
+{/*<publisher>Newfound Press</publisher>*/}
+{/*<pubPlace>Knoxville, Tennessee</pubPlace>*/}
+{/*</docImprint>*/}

--- a/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
+++ b/resources/ut-tei/src/scss/subheader/_polk-landing-page.scss
@@ -1,3 +1,11 @@
+.polk-editor-publisher {
+  margin-bottom: $golden-ratio-4;
+
+  p.editor {
+    text-transform: uppercase;
+  }
+}
+
 .content .polk-logos {
   margin-top: $golden-ratio-4;
   margin-bottom: 76px;


### PR DESCRIPTION
**JIRA Ticket**: [PTC-146](https://jirautk.atlassian.net/projects/PTC/issues/PTC-146)

# What does this Pull Request do?

**Impt:** More complex than it seems.

Michael wanted to add three lines to the homepage Polk Papers.

> Second, nowhere in the edition (as opposed to the Newfound Press gateway) does it list the editor’s name (mine) and the editorial assistant’s (Bradley J. Nichols). It would be nice to have them on the home page, either above the sponsors or in the banner.

This is already content located in the XML, yet TEI Publisher ignores it when rendering.  I chose to insert this content dynamically via a JS prepend so that we didn't make the XML redundant and didn't impede on the ordering of the `<head>` tag on the `<div type="sponsors">` rendered page.

# What's new?

* Updated published date in XML.
* Fixed a bug in my custom JS that wasn't being fired when TEI Publisher jQuery functions were being called.
* Added the requested lines as a prepended `<div>` on the _Sponsored By_ page.
* Added force reload if the _Sponsored By_ page is hit by JS. This is hacky to get around some load ordering conflicts I was having with TEI Publisher.

# How should this be tested?

1. `ant` and upload
2. Review added lines on Sponsored By page.
2. Navigate using keyboard or Next/Previous nav back and forth between sponsored by page and the next. Make sure content loads accordingly.

# Interested parties
@markpbaggett 
